### PR TITLE
ビルド後パスの変動によるバグと endpointの修正

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -3,10 +3,10 @@ import { endpointUrlJoin } from "../src/utils/urljoin";
 export const Apps = {
   DONWLAOD_APP: () => endpointUrlJoin`/apps/download`,
   GET_PRIMARY_APP: ({ projectId }: { projectId: number }) =>
-    endpointUrlJoin`/api/projects/${projectId}/app`,
+    endpointUrlJoin`/projects/${projectId}/app`,
   GET_PROJECT_APPS: ({ projectId }: { projectId: number }) =>
-    endpointUrlJoin`/api/projects/${projectId}/apps`,
-  GET_APP: ({ id }: { id: number }) => `/api/apps/${id}`
+    endpointUrlJoin`/projects/${projectId}/apps`,
+  GET_APP: ({ id }: { id: number }) => `/apps/${id}`
 };
 
 export const Assets = {
@@ -35,11 +35,11 @@ export const Assets = {
   }) => endpointUrlJoin`/assets/${assetId}/file?branchId=${branchId}`,
   CREATE_ASSET: () => endpointUrlJoin`/assets`,
   UPDATE_ASSET: ({ assetId }: { assetId: number }) =>
-    endpointUrlJoin`/api/assets/${assetId}`
+    endpointUrlJoin`/assets/${assetId}`
 };
 
 export const Jobs = {
-  GET_JOBS: (id: number) => endpointUrlJoin`/api/jobs/${id}`
+  GET_JOBS: (id: number) => endpointUrlJoin`/jobs/${id}`
 };
 
 export const Projects = {

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,4 +1,4 @@
-import { endpointUrlJoin } from "../src/utils/urljoin";
+import { endpointUrlJoin } from "./utils/urljoin";
 
 export const Apps = {
   DONWLAOD_APP: () => endpointUrlJoin`/apps/download`,


### PR DESCRIPTION
ビルド後 `src/` から `built/`に変わるため
`Error: Cannot find module '../src/utils/urljoin'`
このようなエラーが発生するのを修正。


一部のエンドポイントが結合後
`https://playcanvas.com/api/api/assets`
のような存在しないURIになってしまうのを修正しました！！！！！！