### PR TITLE
List AssetsのエンドポイントにLIMITの指定を行う

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -16,7 +16,8 @@ export const Assets = {
   }: {
     projectId: number;
     branchId: string;
-  }) => endpointUrlJoin`/projects/${projectId}/assets?branchId=${branchId}`,
+  }) =>
+    endpointUrlJoin`/projects/${projectId}/assets?branchId=${branchId}&limit=${Number.MAX_SAFE_INTEGER}`,
   GET_ASSETS: ({ assetId, branchId }: { assetId: number; branchId: string }) =>
     endpointUrlJoin`/assets/${assetId}?branchId=${branchId}`,
   DELETE_ASSET: ({


### PR DESCRIPTION
クエリパラメータを設定指定ない状態だと、LIST_ASSETSのエンドポイントを参照した際に、16個までのAssetsしか取得できないためLIMITの値を設定

修正前
95個のアセットのあるプロジェクトのアセット一覧を取得する際に16個のアセットしか取得ができていなかった

修正後
95個のアセットを取得できるようになった